### PR TITLE
Use protocol relative URL for webfont

### DIFF
--- a/common/header.php
+++ b/common/header.php
@@ -20,7 +20,7 @@
     <?php fire_plugin_hook('public_head',array('view'=>$this)); ?>
     <!-- Stylesheets -->
     <?php
-    queue_css_url('http://fonts.googleapis.com/css?family=Playfair+Display:700,400|Playfair+Display+SC:400|Raleway:700,400&subset=latin');
+    queue_css_url('//fonts.googleapis.com/css?family=Playfair+Display:700,400|Playfair+Display+SC:400|Raleway:700,400&subset=latin');
     queue_css_file(array('iconfonts', 'style'));
 
     echo head_css();


### PR DESCRIPTION
Fixes font loading problems when a site is viewed over HTTPS.